### PR TITLE
Iptables Restart

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license           "Apache 2.0"
 description       "enable driving cookbooks that are not normally config driven to be so"
 version           "5.0.0"
 
-depends 'iptables-ng', '>= 2.2'
+depends 'iptables-ng'
 depends 'nginx'
 
 %w{ debian ubuntu centos redhat fedora scientific amazon windows }.each do |os|

--- a/recipes/iptables-standard.rb
+++ b/recipes/iptables-standard.rb
@@ -64,6 +64,10 @@ node['iptables-ng']['enabled_ip_versions'].each do |version|
   end
 end
 
+service 'iptables' do
+  action :restart
+end
+
 begin
   f2b_service = resources(:service => 'fail2ban')
   f2b_service.subscribes :restart, 'ruby_block[restart_iptables]', :delayed


### PR DESCRIPTION
Upgrading iptables-ng but also restarting iptables at the end of the changes in config-driven-helper-compat's standard.rb. Tested using server-omnibus kitchen.