### PR TITLE
Fix Deprecated Message/iptables-ng update

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license           "Apache 2.0"
 description       "enable driving cookbooks that are not normally config driven to be so"
 version           "5.0.0"
 
-depends 'iptables-ng', '>= 2.2'
+depends 'iptables-ng', '4.0.0'
 depends 'nginx'
 
 %w{ debian ubuntu centos redhat fedora scientific amazon windows }.each do |os|

--- a/recipes/nginx-sites.rb
+++ b/recipes/nginx-sites.rb
@@ -54,7 +54,16 @@ node['nginx']['sites'].each do |name, site_attrs|
     end if protocol == 'https'
 
     self.send "#{type}_site", name do
-      enable (defined? site['enable'] ? site['enable'] : true)
+      if defined? site['enabled']
+        case site[enabled]
+        when true
+          action :enable
+        else
+          action :nothing
+        end
+      else
+        action :enable
+      end
     end
   end
 


### PR DESCRIPTION
- Fix deprecated message in nginx-sites
- Use updated version of iptables-ng cookbook (2.2 > 4.0.0)

Tested working on server omnibus kitchen though iptables not present following converge. Previous version of iptables was working with iptables-ng 2.2 but appears some nodes restart the service and some don't. That requires further investigation as we move to Cent 7.