### PR TITLE
Fixing a slight syntax error

### DIFF
--- a/recipes/nginx-sites.rb
+++ b/recipes/nginx-sites.rb
@@ -55,7 +55,7 @@ node['nginx']['sites'].each do |name, site_attrs|
 
     self.send "#{type}_site", name do
       if defined? site['enabled']
-        case site[enabled]
+        case site['enabled']
         when true
           action :enable
         else


### PR DESCRIPTION
The missing apostrophes caused the tests to fail even when the dependancy issue within https://github.com/usemarkup/chef-server-omnibus/pull/105 is fixed.